### PR TITLE
Add tab bar support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## master
 ##### New Feature
 
+* Add Tab Bar Support  
+  [Stephen Radford](https://github.com/steve228uk)
+  [#31](https://github.com/toshi0383/TVMLKitchen/pull/31)
+
 * Add Modal Support  
   [Stephen Radford](https://github.com/steve228uk)
   [#26](https://github.com/toshi0383/TVMLKitchen/pull/26)

--- a/README.md
+++ b/README.md
@@ -36,12 +36,39 @@ Kitchen automatically looks for the jsFile in your Main Bundle, parse and load i
 
 ## Presentation Styles
 
-There are currently two presentation styles that can be used when serving views: Default and Modal. The default style acts as a "Push" and will replace the current view. Modal will overlay the new view atop the existing view and is commonly used for alerts.
+There are currently three presentation styles that can be used when serving views: Default, Modal and Tab. The default style acts as a "Push" and will change the current view. Modal will overlay the new view atop the existing view and is commonly used for alerts. Tab is only to be used when defining the first view in a tabcontroller.
 
 ````swift
 Kitchen.serve(jsFile: "Sample.xml.js")
 Kitchen.serve(jsFile: "Sample.xml.js", type: .Default)
 Kitchen.serve(jsFile: "Sample.xml.js", type: .Modal)
+Kitchen.serve(jsFile: "Sample.xml.js", type: .Tab)
+````
+
+## Tab Controller
+
+Should you wish to use tabs within your application you can use `KitchenTabBar`. First, create a `TabItem` struct with a title and a `handler` method. The `handler` method will be called every time the tab becomes active.
+
+**Note:** The `PresentationType` for initial view should always be set to `.Tab`.
+
+````swift
+struct Moviestab: TabItem {
+
+    let title = "Movies"
+
+    func handler() {
+        Kitchen.serve(jsFile: "Sample.xml.js", type: .Tab)
+    }
+
+}
+````
+
+The following should then be included in your `AppDelegate` directly below the `Kitchen.prepare()` method.
+
+````swift
+KitchenTabBar.sharedBar.items = [
+    MoviesTab()
+]
 ````
 
 ## Advanced setup

--- a/TVMLKitchen.xcodeproj/project.pbxproj
+++ b/TVMLKitchen.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		1F5ABB981C356B3100785DEB /* TVMLKitchen.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1F32E4091C30B6EF00F62E88 /* TVMLKitchen.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1F8B43781C35676400C716A7 /* SampleRecipeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8B43771C35676400C716A7 /* SampleRecipeUITests.swift */; };
 		1FB5434A1C32DA6C0015CC66 /* ViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1FB543481C32DA6C0015CC66 /* ViewController.storyboard */; };
+		287B85571C98910800EEF5C8 /* KitchenTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287B85561C98910800EEF5C8 /* KitchenTabBar.swift */; };
+		287B855A1C9891B600EEF5C8 /* TabItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287B85591C9891B600EEF5C8 /* TabItem.swift */; };
 		28D4EC281C97400C00E1F005 /* PresentationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D4EC271C97400C00E1F005 /* PresentationType.swift */; };
 /* End PBXBuildFile section */
 
@@ -116,6 +118,8 @@
 		1F8B43771C35676400C716A7 /* SampleRecipeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleRecipeUITests.swift; sourceTree = "<group>"; };
 		1F8B43791C35676400C716A7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1FB543491C32DA6C0015CC66 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/ViewController.storyboard; sourceTree = "<group>"; };
+		287B85561C98910800EEF5C8 /* KitchenTabBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KitchenTabBar.swift; sourceTree = "<group>"; };
+		287B85591C9891B600EEF5C8 /* TabItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabItem.swift; sourceTree = "<group>"; };
 		28D4EC271C97400C00E1F005 /* PresentationType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentationType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -263,6 +267,7 @@
 		1F32E55C1C30B81200F62E88 /* source */ = {
 			isa = PBXGroup;
 			children = (
+				287B85581C9891AC00EEF5C8 /* Tab Bar */,
 				1F3065B41C30D634001E5DF0 /* js */,
 				1F32E5F61C30B81200F62E88 /* Info.plist */,
 				1F32E5F71C30B81200F62E88 /* TVMLKitchen.h */,
@@ -298,6 +303,15 @@
 				1F8B43791C35676400C716A7 /* Info.plist */,
 			);
 			path = SampleRecipeUITests;
+			sourceTree = "<group>";
+		};
+		287B85581C9891AC00EEF5C8 /* Tab Bar */ = {
+			isa = PBXGroup;
+			children = (
+				287B85561C98910800EEF5C8 /* KitchenTabBar.swift */,
+				287B85591C9891B600EEF5C8 /* TabItem.swift */,
+			);
+			name = "Tab Bar";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -491,6 +505,8 @@
 				1F3065BC1C30D65B001E5DF0 /* TVMLBridging.swift in Sources */,
 				1F32E6871C30B81E00F62E88 /* Kitchen.swift in Sources */,
 				1F3066031C31179A001E5DF0 /* Recipe.swift in Sources */,
+				287B85571C98910800EEF5C8 /* KitchenTabBar.swift in Sources */,
+				287B855A1C9891B600EEF5C8 /* TabItem.swift in Sources */,
 				28D4EC281C97400C00E1F005 /* PresentationType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/source/Kitchen.swift
+++ b/source/Kitchen.swift
@@ -224,14 +224,14 @@ extension Kitchen: TVApplicationControllerDelegate {
             jsContext.setObject(unsafeBitCast(actionIDHandler, AnyObject.self),
                 forKeyedSubscript: "actionIDHandler")
         }
-        
-        
+
+
         // Add the tab bar handler for the shared instance.
-        
+
         let tabBarHandler: @convention(block) String -> Void = { index in
             KitchenTabBar.sharedBar.tabChanged(index)
         }
-        
+
         jsContext.setObject(unsafeBitCast(tabBarHandler, AnyObject.self),
             forKeyedSubscript: "tabBarHandler")
 

--- a/source/Kitchen.swift
+++ b/source/Kitchen.swift
@@ -225,6 +225,9 @@ extension Kitchen: TVApplicationControllerDelegate {
                 forKeyedSubscript: "actionIDHandler")
         }
         
+        
+        // Add the tab bar handler for the shared instance.
+        
         let tabBarHandler: @convention(block) String -> Void = { index in
             KitchenTabBar.sharedBar.tabChanged(index)
         }

--- a/source/Kitchen.swift
+++ b/source/Kitchen.swift
@@ -220,6 +220,13 @@ extension Kitchen: TVApplicationControllerDelegate {
             jsContext.setObject(unsafeBitCast(actionIDHandler, AnyObject.self),
                 forKeyedSubscript: "actionIDHandler")
         }
+        
+        let tabBarHandler: @convention(block) String -> Void = { index in
+            KitchenTabBar.sharedBar.tabChanged(index)
+        }
+        
+        jsContext.setObject(unsafeBitCast(tabBarHandler, AnyObject.self),
+            forKeyedSubscript: "tabBarHandler")
 
         self.evaluateAppJavaScriptInContext?(appController, jsContext)
     }

--- a/source/KitchenTabBar.swift
+++ b/source/KitchenTabBar.swift
@@ -8,14 +8,19 @@
 
 public struct KitchenTabBar {
 
+    /// The shared instance of the tab bar.
+    /// Only one tab bar should be created per app.
     public static var sharedBar = KitchenTabBar()
     
+    /// The items that are displayed in the tab bar.
+    /// The `displayTabBar` method will automatically be called.
     public var items: [TabItem]! {
         didSet {
             displayTabBar()
         }
     }
     
+    /// Constructed string from the `items` array.
     var itemString: String {
         var string = ""
         for (index, item) in items.enumerate() {
@@ -26,6 +31,7 @@ public struct KitchenTabBar {
         return string
     }
     
+    /// The XML string of the `menuBarTemplate`.
     var xmlString: String {
         get {
             var xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>"
@@ -40,10 +46,19 @@ public struct KitchenTabBar {
         }
     }
     
+    /**
+     Display the tab bar using the generated `xmlString`.
+     */
     func displayTabBar() {
         openTVMLTemplateFromXMLString(xmlString)
     }
     
+    /**
+     Called whenever the tab view changes.
+     The handler defined by the relevant `TabItem` will automatically be called.
+     
+     - parameter index: The new selected index
+     */
     func tabChanged(index: String) {
         if let i = Int(index) {
             items[i].handler()

--- a/source/KitchenTabBar.swift
+++ b/source/KitchenTabBar.swift
@@ -11,7 +11,7 @@ public struct KitchenTabBar {
     /// The shared instance of the tab bar.
     /// Only one tab bar should be created per app.
     public static var sharedBar = KitchenTabBar()
-    
+
     /// The items that are displayed in the tab bar.
     /// The `displayTabBar` method will automatically be called.
     public var items: [TabItem]! {
@@ -19,7 +19,7 @@ public struct KitchenTabBar {
             displayTabBar()
         }
     }
-    
+
     /// Constructed string from the `items` array.
     var itemString: String {
         var string = ""
@@ -30,7 +30,7 @@ public struct KitchenTabBar {
         }
         return string
     }
-    
+
     /// The XML string of the `menuBarTemplate`.
     var xmlString: String {
         get {
@@ -45,18 +45,18 @@ public struct KitchenTabBar {
             return xml
         }
     }
-    
+
     /**
      Display the tab bar using the generated `xmlString`.
      */
     func displayTabBar() {
         openTVMLTemplateFromXMLString(xmlString)
     }
-    
+
     /**
      Called whenever the tab view changes.
      The handler defined by the relevant `TabItem` will automatically be called.
-     
+
      - parameter index: The new selected index
      */
     func tabChanged(index: String) {
@@ -64,5 +64,5 @@ public struct KitchenTabBar {
             items[i].handler()
         }
     }
-    
+
 }

--- a/source/KitchenTabBar.swift
+++ b/source/KitchenTabBar.swift
@@ -1,0 +1,53 @@
+//
+//  KitchenTabBar.swift
+//  TVMLKitchen
+//
+//  Created by Stephen Radford on 15/03/2016.
+//  Copyright © 2016 toshi0383. All rights reserved.
+//
+
+public struct KitchenTabBar {
+
+    public static var sharedBar = KitchenTabBar()
+    
+    public var items: [TabItem]! {
+        didSet {
+            displayTabBar()
+        }
+    }
+    
+    var itemString: String {
+        var string = ""
+        for (index, item) in items.enumerate() {
+            string += "<menuItem menuIndex=\"\(index)\">"
+            string += "<title>\(item.title)</title>"
+            string += "</menuItem>"
+        }
+        return string
+    }
+    
+    var xmlString: String {
+        get {
+            var xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>"
+            xml += "<document>"
+            xml += "<menuBarTemplate>"
+            xml += "<menuBar>"
+            xml += itemString
+            xml += "</menuBar>"
+            xml += "</menuBarTemplate>"
+            xml += "</document>"
+            return xml
+        }
+    }
+    
+    func displayTabBar() {
+        openTVMLTemplateFromXMLString(xmlString)
+    }
+    
+    func tabChanged(index: String) {
+        if let i = Int(index) {
+            items[i].handler()
+        }
+    }
+    
+}

--- a/source/PresentationType.swift
+++ b/source/PresentationType.swift
@@ -9,4 +9,5 @@
 public enum PresentationType: Int {
     case Default = 0
     case Modal = 1
+    case Tab = 2
 }

--- a/source/Recipe.swift
+++ b/source/Recipe.swift
@@ -150,7 +150,8 @@ public struct CatalogRecipe<Theme:ThemeType>: RecipeType {
     public let theme: Theme = Theme()
     public let presentationType: PresentationType
 
-    public init(banner: String, sections: [Section], presentationType: PresentationType = .Default) {
+    public init(banner: String, sections: [Section],
+        presentationType: PresentationType = .Default) {
         self.banner = banner
         self.sections = sections
         self.presentationType = presentationType

--- a/source/Recipe.swift
+++ b/source/Recipe.swift
@@ -147,13 +147,13 @@ public struct CatalogRecipe<Theme:ThemeType>: RecipeType {
 
     let banner: String
     let sections: [Section]
-    public let theme: Theme
-    public let presentationType: PresentationType = .Default
+    public let theme: Theme = Theme()
+    public let presentationType: PresentationType
 
-    public init(banner: String, sections: [Section], theme: Theme = Theme()) {
+    public init(banner: String, sections: [Section], presentationType: PresentationType = .Default) {
         self.banner = banner
         self.sections = sections
-        self.theme = theme
+        self.presentationType = presentationType
     }
 
     public var template: String {

--- a/source/TVMLBridging.swift
+++ b/source/TVMLBridging.swift
@@ -7,7 +7,6 @@
 //
 
 internal func openTVMLTemplateFromXMLString(xmlString: String, type: PresentationType = .Default) {
-    print(type.rawValue)
     let js = "openTemplateFromXMLString(`\(xmlString)`, \(type.rawValue));"
     evaluateInTVMLContext(js)
 }

--- a/source/TVMLBridging.swift
+++ b/source/TVMLBridging.swift
@@ -7,6 +7,7 @@
 //
 
 internal func openTVMLTemplateFromXMLString(xmlString: String, type: PresentationType = .Default) {
+    print(type.rawValue)
     let js = "openTemplateFromXMLString(`\(xmlString)`, \(type.rawValue));"
     evaluateInTVMLContext(js)
 }
@@ -20,12 +21,12 @@ internal func openTVMLTemplateFromXMLFile(xmlFile: String,
 }
 
 internal func openTVMLTemplateFromJSFile(jsfile: String, type: PresentationType = .Default) {
-    let js = "openTemplateFromJSFile('\(jsfile)');"
+    let js = "openTemplateFromJSFile('\(jsfile)', \(type.rawValue));"
     evaluateInTVMLContext(js)
 }
 
 internal func openTVMLTemplateFromURL(url: String, type: PresentationType = .Default) {
-    let js = "openTemplateFromURL('\(url)');"
+    let js = "openTemplateFromURL('\(url)', \(type.rawValue));"
     evaluateInTVMLContext(js)
 }
 

--- a/source/TabItem.swift
+++ b/source/TabItem.swift
@@ -8,8 +8,12 @@
 
 public protocol TabItem {
     
+    /// The title that will be displayed on the tab bar.
     var title: String { get }
     
+    /**
+     This handler will be called whenever the focus changes to it.
+     */
     func handler()
     
 }

--- a/source/TabItem.swift
+++ b/source/TabItem.swift
@@ -1,0 +1,15 @@
+//
+//  TabItem.swift
+//  TVMLKitchen
+//
+//  Created by Stephen Radford on 15/03/2016.
+//  Copyright © 2016 toshi0383. All rights reserved.
+//
+
+public protocol TabItem {
+    
+    var title: String { get }
+    
+    func handler()
+    
+}

--- a/source/TabItem.swift
+++ b/source/TabItem.swift
@@ -7,13 +7,13 @@
 //
 
 public protocol TabItem {
-    
+
     /// The title that will be displayed on the tab bar.
     var title: String { get }
-    
+
     /**
      This handler will be called whenever the focus changes to it.
      */
     func handler()
-    
+
 }

--- a/source/js/kitchen.js
+++ b/source/js/kitchen.js
@@ -180,13 +180,10 @@ function loadingTemplate() {
 /// load template from absolute URL
 function loadTemplateFromURL(templateURL, callback, presentationType) {
     var self = this;
-
-    console.log("CALL 1: "+presentationType);
     
     evaluateScripts([templateURL], function(success) {
         if (success) {
             var resource = Template.call(self);
-                    console.log("CALL 2: "+presentationType);
             callback.call(self, resource, presentationType);
         } else {
             var message = `There was an error attempting to load the resource '${resource}' with URL: '${templateURL}'. \n\n Please try again later.`
@@ -217,7 +214,6 @@ function openTemplateFromJSFile(jsFileName, presentationType) {
 }
 
 function openTemplateFromURL(url, presentationType) {
-    console.log("CALL 0:" + presentationType);
     loadTemplateFromURL(`${url}`, openTemplateFromXMLString, presentationType);
 }
 

--- a/source/js/kitchen.js
+++ b/source/js/kitchen.js
@@ -145,7 +145,9 @@ function showLoadingIndicator(presentation) {
  Show the loading indicator for the presentation type passed from UIKit
  */
 function showLoadingIndicatorForType(presentationType) {
-    if (presentationType == 1 || presentationType == 2 || this.loadingIndicatorVisible) {
+    if (presentationType == 1
+        || presentationType == 2
+        || this.loadingIndicatorVisible) {
         return;
     }
 

--- a/source/js/kitchen.js
+++ b/source/js/kitchen.js
@@ -29,6 +29,14 @@ function searchPresenter(xml) {
     }
 }
 
+/**
+ *  Displays an XML string as a "document" within a tab.
+ *  A new document will be created for the tab if it doesn't exist.
+ *
+ *  @param xml The XML string to be presented
+ *
+ *  @return void
+ */
 function menuBarItemPresenter(xml) {
     var feature = currentTab.parentNode.getFeature("MenuBarDocument");
     if (feature) {

--- a/source/js/kitchen.js
+++ b/source/js/kitchen.js
@@ -145,9 +145,9 @@ function showLoadingIndicator(presentation) {
  Show the loading indicator for the presentation type passed from UIKit
  */
 function showLoadingIndicatorForType(presentationType) {
-    if (presentationType == 1
-        || presentationType == 2
-        || this.loadingIndicatorVisible) {
+    if (presentationType == 1 ||
+        presentationType == 2 ||
+        this.loadingIndicatorVisible) {
         return;
     }
 

--- a/source/recipes/AlertRecipe.swift
+++ b/source/recipes/AlertRecipe.swift
@@ -21,7 +21,7 @@ public struct AlertButton {
 public class AlertRecipe: RecipeType {
 
     public let theme = DefaultTheme()
-    public let presentationType = PresentationType.Modal
+    public let presentationType: PresentationType
     public let title: String
     public let description: String
     public let buttons: [AlertButton]
@@ -29,10 +29,11 @@ public class AlertRecipe: RecipeType {
         return "AlertRecipe"
     }
 
-    public init(title: String, description: String, buttons: [AlertButton] = []) {
+    public init(title: String, description: String, buttons: [AlertButton] = [], presentationType: PresentationType = .Modal) {
         self.title = title
         self.description = description
         self.buttons = buttons
+        self.presentationType = presentationType
     }
 
     public var xmlString: String {

--- a/source/recipes/AlertRecipe.swift
+++ b/source/recipes/AlertRecipe.swift
@@ -29,7 +29,9 @@ public class AlertRecipe: RecipeType {
         return "AlertRecipe"
     }
 
-    public init(title: String, description: String, buttons: [AlertButton] = [], presentationType: PresentationType = .Modal) {
+    public init(title: String, description: String,
+        buttons: [AlertButton] = [],
+        presentationType: PresentationType = .Modal) {
         self.title = title
         self.description = description
         self.buttons = buttons


### PR DESCRIPTION
Hello again!

This pull request adds tab bar support to TVMLKitchen. It's not quite finished but I wanted to get your opinion before I tidy it up.

I've created a shared instance of a new object called `KitchenTabBar`. This tab bar has an `items` property that accepts a number of `TabItem` instances. Each `TabItem` features a `title` and a `handler` with the handler being called every time the tab changes.

Here's how you would setup a TVMLKitchen app to use a tab bar:

```
func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {

    Kitchen.prepare(launchOptions, evaluateAppJavaScriptInContext: nil, actionIDHandler: actionIDHandler, playActionIDHandler: playActionIDHandler)

    KitchenTabBar.sharedBar.items = [
        HomeTab(),
        SettingsTab()
    ]

    return true
}
```

And here is what your `HomeTab` struct would look like:

```
struct HomeTab: TabItem {

    let title = "Home"

    func handler() {
        print("Called whenever the tab changes")
        Kitchen.serve(urlString: "https://raw.githubusercontent.com/toshi0383/TVMLKitchen/master/SampleRecipe/Catalog.xml.js", type: .Tab)
    }

}
```

The new `.Tab` presentation type is only to be used whenever a user wishes to keep a view within a tab. It uses a new JS presenter that has been adapted from some of Apple's sample code.

```
function menuBarItemPresenter(xml) {
    var feature = currentTab.parentNode.getFeature("MenuBarDocument");
    if (feature) {
        var currentDoc = feature.getDocument(currentTab);
        if (!currentDoc) {
            feature.setDocument(xml, currentTab);
        }
    }
}
```

![simulator screen shot 15 mar 2016 22 08 42](https://cloud.githubusercontent.com/assets/1169297/13795768/a21db072-eafa-11e5-8e7e-b76df2dd5473.png)
