### PR TITLE
@export import TVMLKit

### DIFF
--- a/source/Kitchen.swift
+++ b/source/Kitchen.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 toshi0383. All rights reserved.
 //
 
-import TVMLKit
+@exported import TVMLKit
 
 public typealias JavaScriptEvaluationHandler = (TVApplicationController, JSContext) -> Void
 public typealias KitchenErrorHandler = NSError -> Void


### PR DESCRIPTION
Exporting TVMLKit.
Users can now refer to TVMLKit classes like TVApplicationController without explicitly write `import TVMLKit` as long as they have `import TVMLKitchen`.
