### PR TITLE
KitchenTabBar: Mark init() public

### DIFF
--- a/Sources/KitchenTabBar.swift
+++ b/Sources/KitchenTabBar.swift
@@ -36,7 +36,7 @@ public struct KitchenTabBar: TemplateRecipeType {
 
     /// for UnitTesting use.
     /// - parameter items:
-    internal init(items: [TabItem]? = nil) {
+    public init(items: [TabItem]? = nil) {
         self.items = items
     }
 


### PR DESCRIPTION
Mark init() public to allow presenting the tabor modaly.
