### PR TITLE
Handle TabItem's handler() when presented via serve(recipe:) method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Kitchen.serve(xmlFile: "Sample.xml", type: .Tab)
 
 ## Tab Controller
 
-Should you wish to use tabs within your application you can use `KitchenTabBar`. First, create a `TabItem` struct with a title and a `handler` method. The `handler` method will be called every time the tab becomes active.
+Should you wish to use tabs within your application you can use `KitchenTabBar` recipe. First, create a `TabItem` struct with a title and a `handler` method. The `handler` method will be called every time the tab becomes active.
 
 **Note:** The `PresentationType` for initial view should always be set to `.Tab`.
 
 ````swift
-struct Moviestab: TabItem {
+struct MoviesTab: TabItem {
 
     let title = "Movies"
 
@@ -75,12 +75,14 @@ struct Moviestab: TabItem {
 }
 ````
 
-The following should then be included in your `AppDelegate` directly below the `Kitchen.prepare()` method.
+Present tabbar using `serve(recipe:)` method.
 
 ````swift
-KitchenTabBar.sharedBar.items = [
-    MoviesTab()
-]
+let tabbar = KitchenTabBar(items:[
+    MoviesTab(),
+    MusicsTab()
+])
+Kitchen.serve(recipe: tabbar)
 ````
 
 # Advanced setup

--- a/SampleRecipe/Base.lproj/ViewController.storyboard
+++ b/SampleRecipe/Base.lproj/ViewController.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" initialViewController="SDq-1u-6R3">
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" initialViewController="SDq-1u-6R3">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -67,6 +67,14 @@
                                 <state key="normal" title="DescriptiveAlertRecipe"/>
                                 <connections>
                                     <action selector="descriptiveAlertRecipe:" destination="SDq-1u-6R3" eventType="primaryActionTriggered" id="vmi-k2-z01"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xLa-qs-drM">
+                                <rect key="frame" x="627" y="387" width="202" height="86"/>
+                                <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
+                                <state key="normal" title="TabBar"/>
+                                <connections>
+                                    <action selector="tabbarRecipe" destination="SDq-1u-6R3" eventType="primaryActionTriggered" id="mt4-zp-uOg"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/SampleRecipe/ViewController.swift
+++ b/SampleRecipe/ViewController.swift
@@ -17,10 +17,36 @@ struct Sample {
 import UIKit
 import TVMLKitchen
 
+class MusicsTab: TabItem {
+    var title: String {
+        return "Musics"
+    }
+    func handler() {
+        Kitchen.serve(xmlFile: "Oneup.xml", type: .Tab)
+    }
+}
+
+class MoviesTab: TabItem {
+    var title: String {
+        return "Movies"
+    }
+    func handler() {
+        Kitchen.serve(xmlFile: "Catalog.xml", type: .Tab)
+    }
+}
+
 class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
+
+    @IBAction func tabbarRecipe() {
+        let tabbar = KitchenTabBar(items: [
+            MoviesTab(),
+            MusicsTab()
+        ])
+        Kitchen.serve(recipe: tabbar)
     }
 
     @IBAction func openCatalogTemplate() {

--- a/Sources/Cookbook.swift
+++ b/Sources/Cookbook.swift
@@ -20,6 +20,8 @@ public class Cookbook {
     public var actionIDHandler: KitchenActionIDHandler?
     /// handles "play" event
     public var playActionIDHandler: KitchenActionIDHandler?
+    /// handles "tabChanged" event
+    public var tabChangedHandler: KitchenTabItemHandler?
 
     /// Subclass object of SearchRecipe.
     /// Required when presenting SearchRecipe somewhere.

--- a/Sources/Kitchen.swift
+++ b/Sources/Kitchen.swift
@@ -398,3 +398,10 @@ extension Kitchen: TVApplicationControllerDelegate {
         self.evaluateAppJavaScriptInContext?(appController, jsContext)
     }
 }
+
+extension Kitchen {
+    @available(*, deprecated, message="Added for backward compatibility. Will be removed in next release.")
+    internal static func setTabBarHandler(handler: KitchenTabItemHandler) {
+        sharedKitchen.cookbook.tabChangedHandler = handler
+    }
+}

--- a/Sources/Kitchen.swift
+++ b/Sources/Kitchen.swift
@@ -11,6 +11,7 @@
 public typealias JavaScriptEvaluationHandler = (TVApplicationController, JSContext) -> Void
 public typealias KitchenErrorHandler = NSError -> Void
 public typealias KitchenActionIDHandler = (String -> Void)
+public typealias KitchenTabItemHandler = (Int -> Void)
 
 let kitchenErrorDomain = "jp.toshi0383.TVMLKitchen.error"
 
@@ -98,6 +99,9 @@ extension Kitchen {
     public static func serve<R: RecipeType>(recipe recipe: R) {
         if let recipe = recipe as? SearchRecipe {
             sharedKitchen.cookbook.searchRecipe = recipe
+        }
+        if let recipe = recipe as? KitchenTabBar {
+            sharedKitchen.cookbook.tabChangedHandler = recipe.tabChanged
         }
         openTVMLTemplateFromXMLString(recipe.xmlString, type: recipe.presentationType)
     }
@@ -383,12 +387,11 @@ extension Kitchen: TVApplicationControllerDelegate {
             forKeyedSubscript: "loadingTemplate")
 
 
-        // Add the tab bar handler for the shared instance.
-
-        let tabBarHandler: @convention(block) String -> Void = { index in
-            KitchenTabBar.sharedBar.tabChanged(index)
+        // Add the tab bar handler
+        let tabBarHandler: @convention(block) Int -> Void = {
+            index in
+            self.cookbook.tabChangedHandler?(index)
         }
-
         jsContext.setObject(unsafeBitCast(tabBarHandler, AnyObject.self),
             forKeyedSubscript: "tabBarHandler")
 

--- a/Sources/KitchenTabBar.swift
+++ b/Sources/KitchenTabBar.swift
@@ -24,6 +24,7 @@ public struct KitchenTabBar: TemplateRecipeType {
 
     /// The shared instance of the tab bar.
     /// Only one tab bar should be created per app.
+    @available(*, deprecated, message="TabBar is not singleton anymore. Will be removed in next release.")
     public static var sharedBar = KitchenTabBar()
 
     /// The items that are displayed in the tab bar.

--- a/Sources/KitchenTabBar.swift
+++ b/Sources/KitchenTabBar.swift
@@ -68,10 +68,8 @@ public struct KitchenTabBar: TemplateRecipeType {
 
      - parameter index: The new selected index
      */
-    func tabChanged(index: String) {
-        if let i = Int(index) {
-            items[i].handler()
-        }
+    func tabChanged(index: Int) {
+        items[index].handler()
     }
 
 }

--- a/Sources/KitchenTabBar.swift
+++ b/Sources/KitchenTabBar.swift
@@ -25,7 +25,11 @@ public struct KitchenTabBar: TemplateRecipeType {
     /// The shared instance of the tab bar.
     /// Only one tab bar should be created per app.
     @available(*, deprecated, message="TabBar is not singleton anymore. Will be removed in next release.")
-    public static var sharedBar = KitchenTabBar()
+    public static var sharedBar = KitchenTabBar() {
+        didSet {
+            Kitchen.setTabBarHandler(sharedBar.tabChanged)
+        }
+    }
 
     /// The items that are displayed in the tab bar.
     /// The `displayTabBar` method will automatically be called.


### PR DESCRIPTION
Addresses #73 

Added tabChangedHandler property to Cookbook.
Will be overwritten on every `serve(recipe:)` call, just as SearchRecipe's handlers.
