### PR TITLE
Remove ModalWithLoadingIndicator PresentationType

### DIFF
--- a/SampleRecipe/Catalog.xml
+++ b/SampleRecipe/Catalog.xml
@@ -22,21 +22,30 @@
             <relatedContent>
               <grid>
                 <section>
-                  <lockup actionID="hello action A" playActionID="playActionIDhello">
+                  <lockup
+                    template="https://raw.githubusercontent.com/toshi0383/TVMLKitchen/navcon/SampleRecipe/Catalog.xml"
+                    presentationType="Default"
+                  >
                     <img src="${this.BASEURL}music_1.lcr" width="308" height="308" />
                     <title class="whiteText">Title 1</title>
                   </lockup>
-                  <lockup actionID="hello action B">
+                  <lockup
+                    template="https://raw.githubusercontent.com/toshi0383/TVMLKitchen/navcon/SampleRecipe/Catalog.xml"
+                    presentationType="DefaultWithLoadingIndicator"
+                  >
                     <img src="${this.BASEURL}music_2.lcr" width="308" height="308" />
                     <title class="whiteText">Title 2</title>
                   </lockup>
-                  <lockup actionID="hello action C">
+                  <lockup
+                    template="https://raw.githubusercontent.com/toshi0383/TVMLKitchen/navcon/SampleRecipe/Catalog.xml"
+                    presentationType="Modal"
+                  >
                     <img src="${this.BASEURL}music_3.lcr" width="308" height="308" />
                     <title class="whiteText">Title 3</title>
                   </lockup>
                   <lockup
-                    template="https://raw.githubusercontent.com/toshi0383/TVMLKitchen/master/SampleRecipe/Oneup.xml"
-                    presentationType="Modal"
+                    template="https://raw.githubusercontent.com/toshi0383/TVMLKitchen/navcon/SampleRecipe/Catalog.xml"
+                    presentationType="ModalWithLoadingIndicator"
                   >
                     <img src="${this.BASEURL}music_4.lcr" width="308" height="308" />
                     <title class="whiteText">Title 4</title>

--- a/SampleRecipe/Catalog.xml
+++ b/SampleRecipe/Catalog.xml
@@ -45,7 +45,6 @@
                   </lockup>
                   <lockup
                     template="https://raw.githubusercontent.com/toshi0383/TVMLKitchen/navcon/SampleRecipe/Catalog.xml"
-                    presentationType="ModalWithLoadingIndicator"
                   >
                     <img src="${this.BASEURL}music_4.lcr" width="308" height="308" />
                     <title class="whiteText">Title 4</title>

--- a/SampleRecipe/ViewController.swift
+++ b/SampleRecipe/ViewController.swift
@@ -10,7 +10,7 @@
 struct Sample {
     static let title = "TVMLKitchen"
     static let description = "Swift is a high-performance system programming language. It has a clean and modern syntax, offers seamless access to existing C and Objective-C code and frameworks, and is memory safe by default."
-    static let tvmlUrl = "https://raw.githubusercontent.com/toshi0383/TVMLKitchen/swift2.2/SampleRecipe/Oneup.xml"
+    static let tvmlUrl = "https://raw.githubusercontent.com/toshi0383/TVMLKitchen/navcon/SampleRecipe/Catalog.xml"
 }
 // swiftlint:enable line_length
 

--- a/SampleRecipe/ViewController.swift
+++ b/SampleRecipe/ViewController.swift
@@ -55,18 +55,18 @@ class ViewController: UIViewController {
     }
 
     @IBAction func openXMLString(sender: AnyObject!) {
-        Kitchen.serve(xmlString:XMLString.Catalog.description, type: .ModalWithLoadingIndicator)
+        Kitchen.serve(xmlString:XMLString.Catalog.description, type: .DefaultWithLoadingIndicator)
     }
 
     @IBAction func openTemplateFromURL(sender: AnyObject!) {
-        Kitchen.serve(urlString: Sample.tvmlUrl, type: .ModalWithLoadingIndicator)
+        Kitchen.serve(urlString: Sample.tvmlUrl, type: .DefaultWithLoadingIndicator)
     }
 
     @IBAction func descriptiveAlertRecipe(sender: AnyObject) {
         let alert = DescriptiveAlertRecipe(
             title: Sample.title,
             description: Sample.description,
-            presentationType: .ModalWithLoadingIndicator
+            presentationType: .Modal
         )
         Kitchen.serve(recipe: alert)
     }

--- a/Sources/PresentationType.swift
+++ b/Sources/PresentationType.swift
@@ -14,7 +14,6 @@ public enum PresentationType: Int {
     /// Mix of `.Tab` and `.Search`.
     /// Expected to be used when presenting SearchRecipe as a TabItem.
     case TabSearch = 4
-    case ModalWithLoadingIndicator = 5
     case DefaultWithLoadingIndicator = 6
 
     init(string: String) {
@@ -27,8 +26,6 @@ public enum PresentationType: Int {
             self = .Search
         case "tabsearch":
             self = .TabSearch
-        case "modalwithloadingindicator":
-            self = .ModalWithLoadingIndicator
         case "defaultwithloadingindicator":
             self = .DefaultWithLoadingIndicator
         default:

--- a/Sources/kitchen.js
+++ b/Sources/kitchen.js
@@ -123,10 +123,10 @@ function makeDocument(resource) {
  */
 function showLoadingIndicatorForType(presentationType) {
     // guard
-    if ((presentationType == 5 || presentationType == 6) &&
+    if (presentationType == 6 &&
         !this.loadingIndicatorVisible) {
     } else {
-        return
+        return;
     }
 
     if (!this.loadingIndicator) {


### PR DESCRIPTION
Dropping this feature due to:
- Modal presentation does not cooperate with loading indicator, since modal views are on different stack from **pushed** views. It had been causing runtime js crash when I tried to.
- Modal views are expected to be presented much more like an alert, without any indicators, in most cases. It's not worth spending so much time debugging to maintain this feature.
