### PR TITLE
Improve Window Transition Animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## swift2.2
+##### Breaking
+* [Multi Window Support] Improve Window Transition Animation  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+  [#108](https://github.com/toshi0383/TVMLKitchen/pull/108)
+
 ## 0.9.3
 ##### Enhancement
 * [Multi Window Support] Reuse UIViewController  

--- a/NativeBaseSample/AppDelegate.swift
+++ b/NativeBaseSample/AppDelegate.swift
@@ -17,6 +17,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         Kitchen.prepare(Cookbook(launchOptions: launchOptions))
+        window?.backgroundColor = .blackColor()
+        Kitchen.window.backgroundColor = .blackColor()
+        Kitchen.navigationController.view.backgroundColor = .blackColor()
         return true
     }
 

--- a/NativeBaseSample/ViewController.swift
+++ b/NativeBaseSample/ViewController.swift
@@ -13,46 +13,52 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        navigationController?.view.backgroundColor = .blackColor()
+        view.backgroundColor = .blackColor()
     }
 
     @IBAction func urlString(sender: AnyObject!) {
         let appdelegateWindow = (UIApplication.sharedApplication().delegate as! AppDelegate).window!
-        Kitchen.window.alpha = 0.0
         Kitchen.serve(
             urlString: Sample.tvmlUrl,
             redirectWindow: appdelegateWindow,
+
+            // - Note: This is what Kitchen would do when animatedWindowTransition is true.
             kitchenWindowWillBecomeVisible: {
-                UIView.animateWithDuration(0.3) {
-                    Kitchen.window.alpha = 1.0
-                    appdelegateWindow.alpha = 0.0
-                }
+                Kitchen.window.alpha = 0.0
+                UIView.animateWithDuration(
+                    0.3,
+                    animations: {
+                        Kitchen.window.alpha = 1.0
+                    },
+                    completion: {
+                        _ in
+                        appdelegateWindow.alpha = 0.0
+                    }
+                )
             },
-            didRedirectToWindow: {
-                UIView.animateWithDuration(0.3) {
-                    Kitchen.window.alpha = 0.0
-                    appdelegateWindow.alpha = 1.0
-                }
+            willRedirectToWindow: {
+                appdelegateWindow.alpha = 0.0
+                UIView.animateWithDuration(
+                    0.3,
+                    animations: {
+                        appdelegateWindow.alpha = 1.0
+                    },
+                    completion: {
+                        _ in
+                        Kitchen.window.alpha = 0.0
+                    }
+                )
             }
         )
     }
     @IBAction func xmlString(sender: AnyObject!) {
         let appdelegateWindow = (UIApplication.sharedApplication().delegate as! AppDelegate).window!
-        Kitchen.window.alpha = 0.0
+        Kitchen.window.alpha = 1.0
         Kitchen.serve(
             xmlString: Sample.tvmlString,
             redirectWindow: appdelegateWindow,
-            kitchenWindowWillBecomeVisible: {
-                UIView.animateWithDuration(0.3) {
-                    Kitchen.window.alpha = 1.0
-                    appdelegateWindow.alpha = 0.0
-                }
-            },
-            didRedirectToWindow: {
-                UIView.animateWithDuration(0.3) {
-                    Kitchen.window.alpha = 0.0
-                    appdelegateWindow.alpha = 1.0
-                }
-            }
+            animatedWindowTransition: true
         )
     }
 }


### PR DESCRIPTION
Users can animate transition automatically by setting `animatedWindowTransition` param to true,
or manually using callbacks.
Callbacks are ignored if `animatedWindowTransition` is true.
