### PR TITLE
[Multi Window] Fixed crashing bug when emptying Kitchen.navigationController during Kitchen.window's presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.5
+##### Bugfix
+* [Multi Window] Fixed crashing bug when emptying Kitchen.navigationController during Kitchen.window's presentation  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+  [#111](https://github.com/toshi0383/TVMLKitchen/pull/111)
+
 ## 0.9.4
 ##### Breaking
 * [Multi Window Support] Improve Window Transition Animation  

--- a/NativeBaseSample/ViewController.swift
+++ b/NativeBaseSample/ViewController.swift
@@ -60,5 +60,16 @@ class ViewController: UIViewController {
             redirectWindow: appdelegateWindow,
             animatedWindowTransition: true
         )
+
+        let seconds: Double = 2.0
+        let nanoSeconds = Int64(seconds * Double(NSEC_PER_SEC))
+        let time = dispatch_time(DISPATCH_TIME_NOW, nanoSeconds)
+        dispatch_after(time, dispatch_get_main_queue()) {
+            self.reset()
+        }
+    }
+    @IBAction func reset() {
+        Kitchen.navigationController.popToRootViewControllerAnimated(false)
+        Kitchen.navigationController.setViewControllers([], animated: false)
     }
 }

--- a/Sources/Kitchen.swift
+++ b/Sources/Kitchen.swift
@@ -341,7 +341,8 @@ extension Kitchen: UINavigationControllerDelegate {
             Kitchen._navigationControllerDelegateWillShowCount = 1
             return
         }
-        if viewController == Kitchen.navigationController.viewControllers[0] {
+        if Kitchen.navigationController.viewControllers.count == 0 ||
+            viewController == Kitchen.navigationController.viewControllers[0] {
             if let redirectWindow = Kitchen.redirectWindow {
                 if Kitchen.animatedWindowTransition {
                     Kitchen._willRedirectToWindow(redirectWindow)

--- a/TVMLKitchen.podspec
+++ b/TVMLKitchen.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "TVMLKitchen"
-  s.version          = "0.9.4"
+  s.version          = "0.9.5"
   s.summary          = "Swifty TVML template manager with or without client-server"
   s.description      = <<-DESC
   TVML is a good choice, when you prefer simplicity over dynamic UIKit implementation. TVMLKitchen helps to manage your TVML with or without additional client-server. Put TVML templates in Main Bundle, then you're ready to go.


### PR DESCRIPTION
Redirect back to the original window instead of crash.
